### PR TITLE
Add separate 'react-addons-*' dependencies

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,3 @@
+[ignore]
+.*/node_modules/fbjs/lib/.*
+.*/node_modules/react/.*

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # react-for-atom
 
-Wrapper around [facebook/react](https://github.com/facebook/react), providing the following modifications:
-
-- When `process.env.NODE_ENV === 'production`, the minified version of React is loaded to reduce package startup time
-
-- Provide `React.addons` lazily to reduce package startup time
+Wrapper around [facebook/react](https://github.com/facebook/react), providing the following
+modifications:
 
 ## A single instance of React
-React does not currently play well with other instances of React on the same page (see [#3252](https://github.com/facebook/react/issues/3252), [#2402](https://github.com/facebook/react/issues/2402)).
+React does not currently play well with other instances of React on the same page
+(see [#3252](https://github.com/facebook/react/issues/3252),
+[#2402](https://github.com/facebook/react/issues/2402)).
 
-Since Atom will soon deprecate `atom.react` (which provides an outdated React build), we propose that __Atom package developers wanting to use React require this package__ instead of other variants of React:
+Since Atom will soon deprecate `atom.react` (which provides an outdated React build), we propose
+that __Atom package developers wanting to use React require this package__ instead of other variants
+of React:
 
 ```js
 var React = require('react-for-atom');
@@ -18,4 +19,5 @@ var React = require('react-for-atom');
 var {addons, PropTypes} = React;
 ```
 
-We plan to closely track the React release cycle in order to be able to use the latest features as well as provide access to React API warnings (in `atom --dev` mode).
+We plan to closely track the React release cycle in order to be able to use the latest features as
+well as provide access to React API warnings (in `atom --dev` mode).

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 'use strict';
+/* @flow */
 
-var React;
+var atom = global.atom;
 
 if (typeof window !== 'undefined') {
   // circumvent React Dev Tools console warning
@@ -9,30 +10,21 @@ if (typeof window !== 'undefined') {
 
 if (typeof atom === 'object' && atom !== null) {
   if (typeof atom.__DO_NOT_ACCESS_React_Singleton === 'undefined') {
-    if (process.env.NODE_ENV === 'production') {
-      React = require('react/dist/react-with-addons.min');
-    } else {
-      React = require('react');
-      var addons;
-      Object.defineProperty(React, 'addons', {
-        get: function get() {
-          if (!addons) {
-            React = require('react/addons');
-          }
-          return addons;
-        },
-        set: function set(val) {
-          addons = val;
-        },
-        enumerable: false,
-      });
-    }
-    atom.__DO_NOT_ACCESS_React_Singleton = React;
+    module.exports.cloneWithProps = require('react-addons-clone-with-props');
+    module.exports.createFragment = require('react-addons-create-fragment');
+    module.exports.CSSTransitionGroup = require('react-addons-css-transition-group');
+    module.exports.Perf = require('react-addons-perf');
+    module.exports.PureRenderMixin = require('react-addons-pure-render-mixin');
+    module.exports.React = require('react');
+    module.exports.ReactDOM = require('react-dom');
+    module.exports.shallowCompare = require('react-addons-shallow-compare');
+    module.exports.TestUtils = require('react-addons-test-utils');
+    module.exports.TransitionGroup = require('react-addons-transition-group');
+    module.exports.update = require('react-addons-update');
+    atom.__DO_NOT_ACCESS_React_Singleton = module.exports;
   } else {
-    React = atom.__DO_NOT_ACCESS_React_Singleton;
+    module.exports = atom.__DO_NOT_ACCESS_React_Singleton;
   }
 } else {
   console.log("Do not use react-for-atom outside of Atom. Use require('react') instead.");
 }
-
-module.exports = React;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,17 @@
   },
   "homepage": "https://github.com/jgebhardt/react-for-atom#readme",
   "dependencies": {
-    "react": "0.14.2"
+    "react": "0.14.6",
+    "react-addons-clone-with-props": "0.14.6",
+    "react-addons-create-fragment": "0.14.6",
+    "react-addons-css-transition-group": "0.14.6",
+    "react-addons-perf": "0.14.6",
+    "react-addons-pure-render-mixin": "0.14.6",
+    "react-addons-shallow-compare": "0.14.6",
+    "react-addons-test-utils": "0.14.6",
+    "react-addons-transition-group": "0.14.6",
+    "react-addons-update": "0.14.6",
+    "react-dom": "0.14.6"
   },
   "devDependencies": {
     "tap": "^2.2.0"

--- a/test.js
+++ b/test.js
@@ -3,25 +3,20 @@
 var test = require('tap').test;
 
 test('react-for-atom', function (t) {
-  t.plan(6);
+  t.plan(7);
 
   global.atom = {};
   var before = Object.keys(require.cache);
-
-  var React = require('./');
-  var addons = React.addons;
-
-  t.ok(addons);
-
+  var ReactForAtom = require('./');
   var after = Object.keys(require.cache);
 
-  if (process.env.NODE_ENV === 'production') {
-    // only 2 new modules should've been loaded
-    t.ok(after.length - before.length === 2);
-  } else {
-    // at least 2 new modules should've been loaded
-    t.ok(after.length - before.length >= 2);
-  }
+  // at least 10 modules should've been loaded, React and its addons
+  t.ok(after.length - before.length >= 10);
+
+  // ensure React and some of its addons exist
+  t.ok(ReactForAtom.shallowCompare);
+  t.ok(ReactForAtom.PureRenderMixin);
+  t.ok(ReactForAtom.React);
 
   // reset the module cache
   after.forEach(function(k) {
@@ -33,14 +28,11 @@ test('react-for-atom', function (t) {
   // make sure the module cache was reset
   t.same(Object.keys(require.cache), before);
 
-  var React2 = require('./');
-  var addons2 = React.addons;
+  var ReactForAtom2 = require('./');
 
   // only one new module should've been loaded-
   // since React was pulled from the "atom" singleton
   t.equal(Object.keys(require.cache).length, before.length + 1);
-
-  t.equal(React, React2);
-  t.equal(addons, addons2);
+  t.equal(ReactForAtom, ReactForAtom2);
 });
 


### PR DESCRIPTION
React is moving to many modules rather than including its addons in the
'react' module. Add all addons (except for
react-addons-linked-state-mixin, which is an antipattern) so they are
used as expected by React.

There is no longer a default export for this package, which means
'react' itself must be destructured from the require like so:

```
// Previously
var React = require('react-for-atom');
import React from 'react-for-atom';

// Now
var {React} = require('react-for-atom');
import {React} from 'react-for-atom';
```

`.addons` is deprecated for the 'react' module, so addons are
flattened to this module's export. To use `PureRenderMixin`, for
example, destructuring is your friend:

```
// Previously
var React = require('react-for-atom');
var {PureRenderMixin} = React.addons;

// Now
var {PureRenderMixin} = require('react-for-atom');
```
