### PR TITLE
Upgrade to React 15.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,18 +18,17 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "react": "0.14.7",
-    "react-addons-clone-with-props": "0.14.7",
-    "react-addons-create-fragment": "0.14.7",
-    "react-addons-css-transition-group": "0.14.7",
-    "react-addons-linked-state-mixin": "0.14.7",
-    "react-addons-perf": "0.14.7",
-    "react-addons-pure-render-mixin": "0.14.7",
-    "react-addons-shallow-compare": "0.14.7",
-    "react-addons-test-utils": "0.14.7",
-    "react-addons-transition-group": "0.14.7",
-    "react-addons-update": "0.14.7",
-    "react-dom": "0.14.7"
+    "react": "15.0.1",
+    "react-addons-create-fragment": "15.0.1",
+    "react-addons-css-transition-group": "15.0.1",
+    "react-addons-linked-state-mixin": "15.0.1",
+    "react-addons-perf": "15.0.1",
+    "react-addons-pure-render-mixin": "15.0.1",
+    "react-addons-shallow-compare": "15.0.1",
+    "react-addons-test-utils": "15.0.1",
+    "react-addons-transition-group": "15.0.1",
+    "react-addons-update": "15.0.1",
+    "react-dom": "15.0.1"
   },
   "devDependencies": {
     "flow-bin": "0.21.0",

--- a/react-for-atom.js
+++ b/react-for-atom.js
@@ -11,7 +11,6 @@ if (typeof atom.__DO_NOT_ACCESS_React_Singleton === 'undefined') {
     window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {};
   }
   var exportables = {
-    cloneWithProps: function() { return require('react-addons-clone-with-props'); },
     createFragment: function() { return require('react-addons-create-fragment'); },
     CSSTransitionGroup: function() { return require('react-addons-css-transition-group'); },
     LinkedStateMixin: function() { return require('react-addons-linked-state-mixin'); },

--- a/react-for-atom.js.flow
+++ b/react-for-atom.js.flow
@@ -13,7 +13,6 @@ import ReactDOM from 'react-dom';
 import ReactDOMServer from 'react-dom/server';
 
 // from `node_modules`:
-import cloneWithProps from 'react-addons-clone-with-props';
 import createFragment from 'react-addons-create-fragment';
 import CSSTransitionGroup from 'react-addons-css-transition-group';
 import LinkedStateMixin from 'react-addons-linked-state-mixin';
@@ -25,7 +24,6 @@ import TransitionGroup from 'react-addons-transition-group';
 import update from 'react-addons-update';
 
 declare export {
-  cloneWithProps,
   createFragment,
   CSSTransitionGroup,
   LinkedStateMixin,

--- a/test/exports.js
+++ b/test/exports.js
@@ -7,8 +7,7 @@ var test = require('tap').test;
 var ReactForAtom = require('../');
 
 test('react-for-atom exports', function (t) {
-  t.plan(13);
-  t.equal(ReactForAtom.cloneWithProps, require('react-addons-clone-with-props'));
+  t.plan(12);
   t.equal(ReactForAtom.createFragment, require('react-addons-create-fragment'));
   t.equal(ReactForAtom.CSSTransitionGroup, require('react-addons-css-transition-group'));
   t.equal(ReactForAtom.LinkedStateMixin, require('react-addons-linked-state-mixin'));

--- a/test/flow-export/exports-ok.js
+++ b/test/flow-export/exports-ok.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 const {
-  cloneWithProps,
   createFragment,
   CSSTransitionGroup,
   LinkedStateMixin,


### PR DESCRIPTION
- 'react-addons-clone-with-props', which was deprecated in v0.14, is now
  gone. See https://facebook.github.io/react/blog/#removed-deprecations
