### PR TITLE
Export minified React when NODE_ENV is "production"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "react-for-atom.js",
   "repository": "jgebhardt/react-for-atom",
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "NODE_ENV=development tap test/*.js && NODE_ENV=production tap test/*.js"
   },
   "dependencies": {
     "react": "15.0.2",

--- a/react-for-atom.js
+++ b/react-for-atom.js
@@ -10,21 +10,37 @@ if (typeof atom.__DO_NOT_ACCESS_React_Singleton === 'undefined') {
     // circumvent React Dev Tools console warning
     window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {};
   }
-  var exportables = {
-    default: function() { return require('react'); },
-    createFragment: function() { return require('react-addons-create-fragment'); },
-    CSSTransitionGroup: function() { return require('react-addons-css-transition-group'); },
-    LinkedStateMixin: function() { return require('react-addons-linked-state-mixin'); },
-    Perf: function() { return require('react-addons-perf'); },
-    PureRenderMixin: function() { return require('react-addons-pure-render-mixin'); },
-    React: function() { return require('react'); },
-    ReactDOM: function() { return require('react-dom'); },
-    ReactDOMServer: function() { return require('react-dom/server'); },
-    shallowCompare: function() { return require('react-addons-shallow-compare'); },
-    TestUtils: function() { return require('react-addons-test-utils'); },
-    TransitionGroup: function() { return require('react-addons-transition-group'); },
-    update: function() { return require('react-addons-update'); },
-  };
+  var exportables = process.env.NODE_ENV !== 'production' ?
+    {
+      default: function() { return require('react'); },
+      createFragment: function() { return require('react-addons-create-fragment'); },
+      CSSTransitionGroup: function() { return require('react-addons-css-transition-group'); },
+      LinkedStateMixin: function() { return require('react-addons-linked-state-mixin'); },
+      Perf: function() { return require('react-addons-perf'); },
+      PureRenderMixin: function() { return require('react-addons-pure-render-mixin'); },
+      React: function() { return require('react'); },
+      ReactDOM: function() { return require('react-dom'); },
+      ReactDOMServer: function() { return require('react-dom/server'); },
+      shallowCompare: function() { return require('react-addons-shallow-compare'); },
+      TestUtils: function() { return require('react-addons-test-utils'); },
+      TransitionGroup: function() { return require('react-addons-transition-group'); },
+      update: function() { return require('react-addons-update'); },
+    } : {
+      // Perf & TestUtils are not available in production.
+      default: function() { return require('react/dist/react-with-addons.min'); },
+      createFragment: function() { return require('react/dist/react-with-addons.min').addons.createFragment; },
+      CSSTransitionGroup: function() { return require('react/dist/react-with-addons.min').addons.CSSTransitionGroup; },
+      LinkedStateMixin: function() { return require('react/dist/react-with-addons.min').addons.LinkedStateMixin; },
+      // Perf: function() { return require('react/dist/react-with-addons.min').addons.Perf; },
+      PureRenderMixin: function() { return require('react/dist/react-with-addons.min').addons.PureRenderMixin; },
+      React: function() { return require('react/dist/react-with-addons.min'); },
+      ReactDOM: function() { return require('react/dist/react-with-addons.min').__SECRET_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED; },
+      ReactDOMServer: function() { return require('react/dist/react-with-addons.min').__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED; },
+      shallowCompare: function() { return require('react/dist/react-with-addons.min').addons.shallowCompare; },
+      // TestUtils: function() { return require('react/dist/react-with-addons.min').addons.TestUtils; },
+      TransitionGroup: function() { return require('react/dist/react-with-addons.min').addons.TransitionGroup; },
+      update: function() { return require('react/dist/react-with-addons.min').addons.update; },
+    };
   Object.keys(exportables).forEach(function(key) {
     Object.defineProperty(module.exports, key, {
       get: function() {

--- a/test/commonjs-exports.js
+++ b/test/commonjs-exports.js
@@ -7,18 +7,42 @@ var test = require('tap').test;
 var ReactForAtom = require('../');
 
 test('react-for-atom commonjs exports', function (t) {
-  t.plan(13);
-  t.equal(ReactForAtom.default, require('react'));
-  t.equal(ReactForAtom.createFragment, require('react-addons-create-fragment'));
-  t.equal(ReactForAtom.CSSTransitionGroup, require('react-addons-css-transition-group'));
-  t.equal(ReactForAtom.LinkedStateMixin, require('react-addons-linked-state-mixin'));
-  t.equal(ReactForAtom.Perf, require('react-addons-perf'));
-  t.equal(ReactForAtom.PureRenderMixin, require('react-addons-pure-render-mixin'));
-  t.equal(ReactForAtom.React, require('react'));
-  t.equal(ReactForAtom.ReactDOM, require('react-dom'));
-  t.equal(ReactForAtom.ReactDOMServer, require('react-dom/server'));
-  t.equal(ReactForAtom.shallowCompare, require('react-addons-shallow-compare'));
-  t.equal(ReactForAtom.TestUtils, require('react-addons-test-utils'));
-  t.equal(ReactForAtom.TransitionGroup, require('react-addons-transition-group'));
-  t.equal(ReactForAtom.update, require('react-addons-update'));
+  t.plan(15);
+
+  if (process.env.NODE_ENV !== 'production') {
+    t.equal(ReactForAtom.default, require('react'));
+    t.equal(ReactForAtom.createFragment, require('react-addons-create-fragment'));
+    t.equal(ReactForAtom.CSSTransitionGroup, require('react-addons-css-transition-group'));
+    t.equal(ReactForAtom.LinkedStateMixin, require('react-addons-linked-state-mixin'));
+    t.equal(ReactForAtom.Perf, require('react-addons-perf'));
+    t.equal(ReactForAtom.PureRenderMixin, require('react-addons-pure-render-mixin'));
+    t.equal(ReactForAtom.React, require('react'));
+    t.equal(ReactForAtom.ReactDOM, require('react-dom'));
+    t.equal(ReactForAtom.ReactDOMServer, require('react-dom/server'));
+    t.equal(ReactForAtom.shallowCompare, require('react-addons-shallow-compare'));
+    t.equal(ReactForAtom.TestUtils, require('react-addons-test-utils'));
+    t.equal(ReactForAtom.TransitionGroup, require('react-addons-transition-group'));
+    t.equal(ReactForAtom.update, require('react-addons-update'));
+    t.equal(Object.keys(ReactForAtom).length, 13);
+  } else {
+    t.equal(ReactForAtom.default, require('react/dist/react-with-addons.min'));
+    t.equal(ReactForAtom.createFragment, require('react/dist/react-with-addons.min').addons.createFragment);
+    t.equal(ReactForAtom.CSSTransitionGroup, require('react/dist/react-with-addons.min').addons.CSSTransitionGroup);
+    t.equal(ReactForAtom.LinkedStateMixin, require('react/dist/react-with-addons.min').addons.LinkedStateMixin);
+    t.notOk('Perf' in ReactForAtom);
+    t.equal(ReactForAtom.PureRenderMixin, require('react/dist/react-with-addons.min').addons.PureRenderMixin);
+    t.equal(ReactForAtom.React, require('react/dist/react-with-addons.min'));
+    t.equal(ReactForAtom.ReactDOM, require('react/dist/react-with-addons.min').__SECRET_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED);
+    t.equal(ReactForAtom.ReactDOMServer, require('react/dist/react-with-addons.min').__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED);
+    t.equal(ReactForAtom.shallowCompare, require('react/dist/react-with-addons.min').addons.shallowCompare);
+    t.notOk('TestUtils' in ReactForAtom);
+    t.equal(ReactForAtom.TransitionGroup, require('react/dist/react-with-addons.min').addons.TransitionGroup);
+    t.equal(ReactForAtom.update, require('react/dist/react-with-addons.min').addons.update);
+    t.equal(Object.keys(ReactForAtom).length, 11);
+  }
+
+  var everyExportHasAValue = Object.keys(ReactForAtom).every(function(key) {
+    return typeof ReactForAtom[key] !== 'undefined';
+  });
+  t.ok(everyExportHasAValue);
 });

--- a/test/es-module-named-exports.js
+++ b/test/es-module-named-exports.js
@@ -15,13 +15,13 @@ test('react-for-atom es-module named exports', function (t) {
     '  createFragment,',
     '  CSSTransitionGroup,',
     '  LinkedStateMixin,',
-    '  Perf,',
+    process.env.NODE_ENV !== 'production' ? '  Perf,' : '',
     '  PureRenderMixin,',
     '  React,',
     '  ReactDOM,',
     '  ReactDOMServer,',
     '  shallowCompare,',
-    '  TestUtils,',
+    process.env.NODE_ENV !== 'production' ? '  TestUtils,' : '' ,
     '  TransitionGroup,',
     '  update,',
     '} from "..";',
@@ -31,13 +31,13 @@ test('react-for-atom es-module named exports', function (t) {
     '  createFragment,',
     '  CSSTransitionGroup,',
     '  LinkedStateMixin,',
-    '  Perf,',
+    process.env.NODE_ENV !== 'production' ? '  Perf,' : '',
     '  PureRenderMixin,',
     '  React,',
     '  ReactDOM,',
     '  ReactDOMServer,',
     '  shallowCompare,',
-    '  TestUtils,',
+    process.env.NODE_ENV !== 'production' ? '  TestUtils,' : '',
     '  TransitionGroup,',
     '  update,',
     '};',
@@ -52,17 +52,34 @@ test('react-for-atom es-module named exports', function (t) {
   };
   vm.runInNewContext(code, c);
 
-  t.equal(c.module.exports.ReactDefault, require('react'));
-  t.equal(c.module.exports.createFragment, require('react-addons-create-fragment'));
-  t.equal(c.module.exports.CSSTransitionGroup, require('react-addons-css-transition-group'));
-  t.equal(c.module.exports.LinkedStateMixin, require('react-addons-linked-state-mixin'));
-  t.equal(c.module.exports.Perf, require('react-addons-perf'));
-  t.equal(c.module.exports.PureRenderMixin, require('react-addons-pure-render-mixin'));
-  t.equal(c.module.exports.React, require('react'));
-  t.equal(c.module.exports.ReactDOM, require('react-dom'));
-  t.equal(c.module.exports.ReactDOMServer, require('react-dom/server'));
-  t.equal(c.module.exports.shallowCompare, require('react-addons-shallow-compare'));
-  t.equal(c.module.exports.TestUtils, require('react-addons-test-utils'));
-  t.equal(c.module.exports.TransitionGroup, require('react-addons-transition-group'));
-  t.equal(c.module.exports.update, require('react-addons-update'));
+  if (process.env.NODE_ENV !== 'production') {
+    t.equal(c.module.exports.ReactDefault, require('react'));
+    t.equal(c.module.exports.createFragment, require('react-addons-create-fragment'));
+    t.equal(c.module.exports.CSSTransitionGroup, require('react-addons-css-transition-group'));
+    t.equal(c.module.exports.LinkedStateMixin, require('react-addons-linked-state-mixin'));
+    t.equal(c.module.exports.Perf, require('react-addons-perf'));
+    t.equal(c.module.exports.PureRenderMixin, require('react-addons-pure-render-mixin'));
+    t.equal(c.module.exports.React, require('react'));
+    t.equal(c.module.exports.ReactDOM, require('react-dom'));
+    t.equal(c.module.exports.ReactDOMServer, require('react-dom/server'));
+    t.equal(c.module.exports.shallowCompare, require('react-addons-shallow-compare'));
+    t.equal(c.module.exports.TestUtils, require('react-addons-test-utils'));
+    t.equal(c.module.exports.TransitionGroup, require('react-addons-transition-group'));
+    t.equal(c.module.exports.update, require('react-addons-update'));
+  } else {
+    t.equal(c.module.exports.ReactDefault, require('react/dist/react-with-addons.min'));
+    t.equal(c.module.exports.createFragment, require('react/dist/react-with-addons.min').addons.createFragment);
+    t.equal(c.module.exports.CSSTransitionGroup, require('react/dist/react-with-addons.min').addons.CSSTransitionGroup);
+    t.equal(c.module.exports.LinkedStateMixin, require('react/dist/react-with-addons.min').addons.LinkedStateMixin);
+    t.notOk('Perf' in c.module.exports);
+    t.equal(c.module.exports.PureRenderMixin, require('react/dist/react-with-addons.min').addons.PureRenderMixin);
+    t.equal(c.module.exports.React, require('react/dist/react-with-addons.min'));
+    t.equal(c.module.exports.ReactDOM, require('react/dist/react-with-addons.min').__SECRET_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED);
+    t.equal(c.module.exports.ReactDOMServer, require('react/dist/react-with-addons.min').__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED);
+    t.equal(c.module.exports.shallowCompare, require('react/dist/react-with-addons.min').addons.shallowCompare);
+    t.notOk('TestUtils' in c.module.exports);
+    t.equal(c.module.exports.TransitionGroup, require('react/dist/react-with-addons.min').addons.TransitionGroup);
+    t.equal(c.module.exports.update, require('react/dist/react-with-addons.min').addons.update);
+  }
+
 });

--- a/test/es-module-namespace-exports.js
+++ b/test/es-module-namespace-exports.js
@@ -23,19 +23,36 @@ test('react-for-atom es-module namespace exports', function (t) {
   };
   vm.runInNewContext(code, c);
 
-  t.same(c.module.exports, {
-    default: require('react'),
-    createFragment: require('react-addons-create-fragment'),
-    CSSTransitionGroup: require('react-addons-css-transition-group'),
-    LinkedStateMixin: require('react-addons-linked-state-mixin'),
-    Perf: require('react-addons-perf'),
-    PureRenderMixin: require('react-addons-pure-render-mixin'),
-    React: require('react'),
-    ReactDOM: require('react-dom'),
-    ReactDOMServer: require('react-dom/server'),
-    shallowCompare: require('react-addons-shallow-compare'),
-    TestUtils: require('react-addons-test-utils'),
-    TransitionGroup: require('react-addons-transition-group'),
-    update: require('react-addons-update'),
-  });
+  if (process.env.NODE_ENV !== 'production') {
+    t.same(c.module.exports, {
+      default: require('react'),
+      createFragment: require('react-addons-create-fragment'),
+      CSSTransitionGroup: require('react-addons-css-transition-group'),
+      LinkedStateMixin: require('react-addons-linked-state-mixin'),
+      Perf: require('react-addons-perf'),
+      PureRenderMixin: require('react-addons-pure-render-mixin'),
+      React: require('react'),
+      ReactDOM: require('react-dom'),
+      ReactDOMServer: require('react-dom/server'),
+      shallowCompare: require('react-addons-shallow-compare'),
+      TestUtils: require('react-addons-test-utils'),
+      TransitionGroup: require('react-addons-transition-group'),
+      update: require('react-addons-update'),
+    });
+  } else {
+    // Perf & TestUtils are not available in production.
+    t.same(c.module.exports, {
+      default: require('react/dist/react-with-addons.min'),
+      createFragment: require('react/dist/react-with-addons.min').addons.createFragment,
+      CSSTransitionGroup: require('react/dist/react-with-addons.min').addons.CSSTransitionGroup,
+      LinkedStateMixin: require('react/dist/react-with-addons.min').addons.LinkedStateMixin,
+      PureRenderMixin: require('react/dist/react-with-addons.min').addons.PureRenderMixin,
+      React: require('react/dist/react-with-addons.min'),
+      ReactDOM: require('react/dist/react-with-addons.min').__SECRET_DOM_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+      ReactDOMServer: require('react/dist/react-with-addons.min').__SECRET_DOM_SERVER_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+      shallowCompare: require('react/dist/react-with-addons.min').addons.shallowCompare,
+      TransitionGroup: require('react/dist/react-with-addons.min').addons.TransitionGroup,
+      update: require('react/dist/react-with-addons.min').addons.update,
+    });
+  }
 });

--- a/test/lazy-loading.js
+++ b/test/lazy-loading.js
@@ -19,6 +19,10 @@ test('react-for-atom lazy loading', function (t) {
   Object.keys(ReactForAtom1).forEach(function(key) { ReactForAtom1[key]; });
   var after1 = Object.keys(require.cache);
 
-  // verify module loading - must be some large number
-  t.ok(after1.length - before.length > 100);
+  // verify module loading - must be some large number in development
+  if (process.env.NODE_ENV === 'production') {
+    t.equal(after1.length - before.length, 2);
+  } else {
+    t.ok(after1.length - before.length > 100);
+  }
 });


### PR DESCRIPTION
A better way to see this PR is without whitespace: https://github.com/jgebhardt/react-for-atom/compare/with-node-env?expand=1&w=1.

Fixes #13.

Tested this against Nuclide and it's tests.
